### PR TITLE
replace redirect with wrapoperation

### DIFF
--- a/src/client/java/namelessju/scathapro/mixin/MouseHandlerMixin.java
+++ b/src/client/java/namelessju/scathapro/mixin/MouseHandlerMixin.java
@@ -1,5 +1,7 @@
 package namelessju.scathapro.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import namelessju.scathapro.ScathaPro;
 import net.minecraft.client.MouseHandler;
 import net.minecraft.client.OptionInstance;
@@ -9,7 +11,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MouseHandler.class)
@@ -32,8 +33,8 @@ public abstract class MouseHandlerMixin
             ci.cancel();
         }
     }
-    
-    @Redirect(
+
+    @WrapOperation(
         method = "turnPlayer",
         at = @At(
             value = "INVOKE",
@@ -41,12 +42,12 @@ public abstract class MouseHandlerMixin
             ordinal = 0
         )
     )
-    private Object modifySensitivity(OptionInstance<?> instance)
+    private Object modifySensitivity(OptionInstance<?> instance, Operation<?> original)
     {
         if (ScathaPro.getInstance().inputManager.isAlternativeSensitivityEnabled())
         {
             return (double) ScathaPro.getInstance().config.miscellaneous.alternativeSensitivity.get();
         }
-        return instance.get();
+        return original.call(instance);
     }
 }


### PR DESCRIPTION
redirects will cause a crash if any other mod also attempts to redirect this, and many mods do inject to this same target, so a wrapop is safer here